### PR TITLE
feat: add no-extraneous-dependencies rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,54 +86,60 @@
         "tsx": "never"
       }
     ],
-        "sort-imports": [
-          "error",
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": false,
+        "ignoreDeclarationSort": true, // don"t want to sort import lines, use eslint-plugin-import instead
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": [
+          "none",
+          "all",
+          "multiple",
+          "single"
+        ],
+        "allowSeparatedGroups": true
+      }
+    ],
+    // turn on errors for missing imports
+    "import/no-unresolved": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ],
+    // 'import/no-named-as-default-member': 'off',
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin", // Built-in imports (come from NodeJS native) go first
+          "external", // <- External imports
+          "internal", // <- Absolute imports
+          [
+            "sibling",
+            "parent"
+          ], // <- Relative imports, the sibling and parent types they can be mingled together
+          "index", // <- index imports
+          "unknown" // <- unknown
+        ],
+        "pathGroups": [
           {
-            "ignoreCase": false,
-            "ignoreDeclarationSort": true, // don"t want to sort import lines, use eslint-plugin-import instead
-            "ignoreMemberSort": false,
-            "memberSyntaxSortOrder": [
-              "none",
-              "all",
-              "multiple",
-              "single"
-            ],
-            "allowSeparatedGroups": true
+            "pattern": "public/**",
+            "group": "internal",
+            "position": "after"
           }
         ],
-        // turn on errors for missing imports
-        "import/no-unresolved": "error",
-        // 'import/no-named-as-default-member': 'off',
-        "import/order": [
-          "error",
-          {
-            "groups": [
-              "builtin", // Built-in imports (come from NodeJS native) go first
-              "external", // <- External imports
-              "internal", // <- Absolute imports
-              [
-                "sibling",
-                "parent"
-              ], // <- Relative imports, the sibling and parent types they can be mingled together
-              "index", // <- index imports
-              "unknown" // <- unknown
-            ],
-            "pathGroups": [
-              {
-                "pattern": "public/**",
-                "group": "internal",
-                "position": "after"
-              }
-            ],
-            "newlines-between": "always",
-            "alphabetize": {
-              /* sort in ascending order. Options: ["ignore", "asc", "desc"] */
-              "order": "asc",
-              /* ignore case. Options: [true, false] */
-              "caseInsensitive": true
-            }
-          }
-        ]
+        "newlines-between": "always",
+        "alphabetize": {
+          /* sort in ascending order. Options: ["ignore", "asc", "desc"] */
+          "order": "asc",
+          /* ignore case. Options: [true, false] */
+          "caseInsensitive": true
+        }
+      }
+    ]
   },
   "ignorePatterns": [
     "node_modules/*",


### PR DESCRIPTION
**Changes**

- Added rule for no-extraneous-dependencies

**Notes**
Installing any dev dependency will result in 
`error  'package_name' should be listed in the project's dependencies. Run 'npm i -S package_name' to add it        import/no-extraneous-dependencies
`
this will resolve that issue.

Another fix was:
reload VSC or remove node_modules and reinstall packages.

